### PR TITLE
Add github-perl-helpers bin scripts to /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,9 @@ RUN cpm install -g --show-build-log-on-failure --cpanfile /tmp/cpanfile
 
 RUN cpan-outdated --exclude-core -p | xargs -n1 cpanm
 
+WORKDIR /tmp/
+RUN git clone https://github.com/oalders/github-perl-helpers.git --depth 1 && \
+    cp github-perl-helpers/bin/* /usr/local/bin/ && \
+    rm -rf github-perl-helpers
+
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
         apt-get -y --no-install-recommends install aspell aspell-en
 
 RUN cpanm --self-upgrade || \
-	( echo "# Installing cpanminus:"; curl -sL https://cpanmin.us/ | perl - App::cpanminus )
+    ( echo "# Installing cpanminus:"; curl -sL https://cpanmin.us/ | perl - App::cpanminus )
 
 RUN cpanm -nq App::cpm Carton::Snapshot
 


### PR DESCRIPTION
I ran a test build of 5.30 and the bin scripts are in the `$PATH`, so I'm hopeful this should "just work".