### PR TITLE
Use new helpers repo URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN cpm install -g --show-build-log-on-failure --cpanfile /tmp/cpanfile
 RUN cpan-outdated --exclude-core -p | xargs -n1 cpanm
 
 WORKDIR /tmp/
-RUN git clone https://github.com/oalders/ci-perl-helpers.git --depth 1 && \
-    cp ci-perl-helpers/bin/* /usr/local/bin/ && \
-    rm -rf ci-perl-helpers
+RUN git clone https://github.com/oalders/ci-perl-tester-helpers.git --depth 1 && \
+    cp ci-perl-tester-helpers/bin/* /usr/local/bin/ && \
+    rm -rf ci-perl-tester-helpers
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Changed the name of the helpers in order to disambiguate from another
project with the same name.