### PR TITLE
Swapping everything out for `buster`.

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -9,14 +9,30 @@ on:
     - cron: "10 6 * * *"
 
 jobs:
+
   build:
+    name: "Build latest"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish to Registry
+        uses: elgohr/Publish-Docker-Github-Action@3.04
+        with:
+          name: ${{ secrets.DOCKER_REPO }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
+          dockerfile: Dockerfile
+          buildargs: BASE=buster
+          tags: ["latest","buster"]
+
+  build:
+    name: "Build versions"
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         perl-version:
-          - "latest"
           - "5.34"
           - "5.32"
           - "5.30"
@@ -41,5 +57,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
           dockerfile: Dockerfile
-          buildargs: BASE=${{ matrix.perl-version }}
+          buildargs: BASE=${{ matrix.perl-version }}-buster
           tags: "${{ matrix.perl-version }}"

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
 
-  build:
+  latest-build:
     name: "Build latest"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -23,7 +23,7 @@ jobs:
           password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
           dockerfile: Dockerfile
           buildargs: BASE=buster
-          tags: ["latest","buster"]
+          tags: "latest,buster"
 
   build:
     name: "Build versions"

--- a/.github/workflows/test-cpanfile.yml
+++ b/.github/workflows/test-cpanfile.yml
@@ -9,7 +9,7 @@ jobs:
   test-job:
     runs-on: ubuntu-latest
     container:
-      image: perl:${{ matrix.perl-version }}-stretch
+      image: perl:${{ matrix.perl-version }}-buster
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-cpanfile.yml
+++ b/.github/workflows/test-cpanfile.yml
@@ -9,7 +9,7 @@ jobs:
   test-job:
     runs-on: ubuntu-latest
     container:
-      image: perl:${{ matrix.perl-version }}
+      image: perl:${{ matrix.perl-version }}-stretch
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE
-FROM perl:${BASE}-stretch
+FROM perl:${BASE}-buster
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE
-FROM perl:${BASE}
+FROM perl:${BASE}-stretch
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE
-FROM perl:${BASE}-buster
+FROM perl:${BASE}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
Per #19 , this switches out the images for `-buster` variants. I had to split the workflow for numbered versions and `latest`, this way it would play nice.