### PR TITLE
Only install Pod::Readme for Perl >= 5.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ on failures.
 ## Only on Perl 5.10 and later
 
 - Code::TidyAll::Plugin::Test::Vars
-- Pod::Readme
 - Test::Vars
+
+## Only on Perl 5.12 and later
+
+- Pod::Readme
 
 ## Only on Perl 5.14 and later
 

--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,7 @@ requires 'Module::Build';
 requires 'Perl::Critic';
 requires 'Perl::Tidy';
 requires 'Plack::Test';
-requires 'Pod::Readme' if "$]" >= 5.010001;
+requires 'Pod::Readme' if "$]" >= 5.012000;
 requires 'Software::License::Perl_5';
 requires 'Test2::Bundle::Extended';
 requires 'Test2::Plugin::NoWarnings';


### PR DESCRIPTION
Fixes GH #25

Getopt-Long-Descriptive-0.110 needs Perl v5.12.0