### PR TITLE
Add 5.36 to Perl versions

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -34,6 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
+          - "5.36"
           - "5.34"
           - "5.32"
           - "5.30"

--- a/.github/workflows/test-cpanfile.yml
+++ b/.github/workflows/test-cpanfile.yml
@@ -29,6 +29,7 @@ jobs:
           - '5.30'
           - '5.32'
           - '5.34'
+          - '5.36'
     name: Perl ${{ matrix.perl-version }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Bump checkout action from v2 to v3
- Add 5.36 to Perl versions

Fixed #30
