### PR TITLE
Disable cpan-outdated for Perl 5.8

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -59,5 +59,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
           dockerfile: Dockerfile
-          buildargs: BASE=${{ matrix.perl-version }}-buster
+          buildargs: BASE=${{ matrix.perl-version }}-buster,CPANOUTDATED=${{ matrix.perl-version != '5.8' }}
           tags: "${{ matrix.perl-version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE
+ARG CPANOUTDATED
 FROM perl:${BASE}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -18,7 +19,7 @@ RUN cpanm -nq App::cpm Carton::Snapshot
 
 RUN cpm install -g --show-build-log-on-failure --cpanfile /tmp/cpanfile
 
-RUN cpan-outdated --exclude-core -p | xargs -n1 cpanm
+RUN if [ "x${CPANOUTDATED}" = "x1" ] ; then cpan-outdated --exclude-core -p | xargs -n1 cpanm ; else cpan-outdated --exclude-core -p; fi
 
 WORKDIR /tmp/
 RUN git clone https://github.com/perl-actions/ci-perl-tester-helpers.git --depth 1 && \


### PR DESCRIPTION
Attempt to disable cpan-outdated update for older Per version.

We are currently updating Perl-Critic to 1.144 on 5.8 whereas we pin it at 1.142 in the cpanfile.

Refs: #34