### PR TITLE
cpanfile: add Test2-Harness and JUnit formatter

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -52,7 +52,12 @@ if ( "$]" >= 5.010 ) {
     requires 'Devel::Cover::Report::Codecov';
     requires 'Devel::Cover::Report::Coveralls';
     requires 'Minilla';
+    requires 'Test2::Harness';
     requires 'Test::Vars';
+}
+
+if ( "$]" >= 5.010001 ) {
+    requires 'Test2::Harness::Renderer::JUnit';
 }
 
 if ( "$]" >= 5.012 ) {


### PR DESCRIPTION
These allow testing with yath, which is a big step up from prove.

The JUnit formatter means that a JUnit XML file can be spit out from tests, which can be processed by (for example) mikepenz/action-junit-report, to get nicely formatted test reports in the GitHub UI.

This fixes #36 