### PR TITLE
Add a global git safe directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ "x${CPANOUTDATED}" = "x1" ] ; then cpan-outdated --exclude-core -p | xa
 WORKDIR /tmp/
 RUN git clone https://github.com/perl-actions/ci-perl-tester-helpers.git --depth 1 && \
     cp ci-perl-tester-helpers/bin/* /usr/local/bin/ && \
-    rm -rf ci-perl-tester-helpers
+    rm -rf ci-perl-tester-helpers && \
+    git config --global --add safe.directory '*'
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
After this change:

root@390257b4c39c:/tmp# git config --global --list
safe.directory=*

This fixes file ownership mismatches between Docker and the GitHub CI
user which happen via the checkout action. We can likely revert this if
it gets fixed upstream.
