### PR TITLE
Add safe.directory at system rather than global

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ WORKDIR /tmp/
 RUN git clone https://github.com/perl-actions/ci-perl-tester-helpers.git --depth 1 && \
     cp ci-perl-tester-helpers/bin/* /usr/local/bin/ && \
     rm -rf ci-perl-tester-helpers && \
-    git config --global --add safe.directory '*'
+    git config --system --add safe.directory '*'
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
It's possible that GitHub actions are messing with the global config, so
let's try setting the safe directory at the system level.
