### PR TITLE
Add devel build

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -34,6 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
+          - "devel"
           - "5.36"
           - "5.34"
           - "5.32"

--- a/.github/workflows/test-cpanfile.yml
+++ b/.github/workflows/test-cpanfile.yml
@@ -15,26 +15,27 @@ jobs:
       fail-fast: false
       matrix:
         perl-version:
-          - '5.8'
-          - '5.10'
-          - '5.12'
-          - '5.14'
-          - '5.16'
-          - '5.18'
-          - '5.20'
-          - '5.22'
-          - '5.24'
-          - '5.26'
-          - '5.28'
-          - '5.30'
-          - '5.32'
-          - '5.34'
+          - 'devel'
           - '5.36'
+          - '5.34'
+          - '5.32'
+          - '5.30'
+          - '5.28'
+          - '5.26'
+          - '5.24'
+          - '5.22'
+          - '5.20'
+          - '5.18'
+          - '5.16'
+          - '5.14'
+          - '5.12'
+          - '5.10'
+          - '5.8'
     name: Perl ${{ matrix.perl-version }}
     steps:
       - uses: actions/checkout@v3
       - name: Install deps using cpm
-        uses: perl-actions/install-with-cpm@v1
+        uses: perl-actions/install-with-cpm@stable
         with:
           cpanfile: 'cpanfile'
           sudo: false

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The images can be found at [https://hub.docker.com/repository/docker/perldocker/
 The following tags are available from the repository `perldocker/perl-tester`
 
 ```
+devel
 5.36
 5.34
 5.32
@@ -95,6 +96,15 @@ The following tags are available from the repository `perldocker/perl-tester`
 5.10
 5.8
 ```
+
+## devel build
+
+Note that the `devel` build was added to test on the current Perl development version. (example: `5.37.8`, )
+This is tracking the last Perl `devel` version released.
+
+## OS flavor
+
+At this time all the images built are based on `buster` distro.
 
 # Continuous Integrations
 


### PR DESCRIPTION
Fix #45

This is using perl:devel-buster build in addition
to the other stable builds.