### PR TITLE
Use perl-actions/perl-versions to build perl-versions matrix

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -10,6 +10,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    name: List perl versions
+    outputs:
+      perl-versions: ${{ steps.action.outputs.perl-versions }}
+    steps:
+      - name: Perl versions action step
+        id: action
+        uses: perl-actions/perl-versions@main
+        with:
+          since-perl: '5.8'
+          with-devel: 'true'
 
   latest-build:
     name: "Build latest"
@@ -29,28 +41,13 @@ jobs:
   build:
     name: "Build versions"
     runs-on: ubuntu-latest
+    needs:
+      - prepare-matrix
 
     strategy:
       fail-fast: false
       matrix:
-        perl-version:
-          - "devel"
-          - "5.38"
-          - "5.36"
-          - "5.34"
-          - "5.32"
-          - "5.30"
-          - "5.28"
-          - "5.26"
-          - "5.24"
-          - "5.22"
-          - "5.20"
-          - "5.18"
-          - "5.16"
-          - "5.14"
-          - "5.12"
-          - "5.10"
-          - "5.8"
+        perl-version: ${{ fromJson (needs.prepare-matrix.outputs.perl-versions) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-cpanfile.yml
+++ b/.github/workflows/test-cpanfile.yml
@@ -7,31 +7,29 @@ on:
       - '*'
   workflow_dispatch:
 jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    name: List perl versions
+    outputs:
+      perl-versions: ${{ steps.action.outputs.perl-versions }}
+    steps:
+      - name: Perl versions action step
+        id: action
+        uses: perl-actions/perl-versions@main
+        with:
+          since-perl: '5.8'
+          with-devel: 'true'
+
   test-job:
     runs-on: ubuntu-latest
+    needs:
+      - prepare-matrix
     container:
       image: perl:${{ matrix.perl-version }}-buster
     strategy:
       fail-fast: false
       matrix:
-        perl-version:
-          - 'devel'
-          - '5.38'
-          - '5.36'
-          - '5.34'
-          - '5.32'
-          - '5.30'
-          - '5.28'
-          - '5.26'
-          - '5.24'
-          - '5.22'
-          - '5.20'
-          - '5.18'
-          - '5.16'
-          - '5.14'
-          - '5.12'
-          - '5.10'
-          - '5.8'
+        perl-version: ${{ fromJson (needs.prepare-matrix.outputs.perl-versions) }}
     name: Perl ${{ matrix.perl-version }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
to maintain single list of available perl versions

Advantage
- new versions will automatically spread

Disadvantage:
- there will be some delay between committing new version and new docker image available
