### PR TITLE
Build images for bookworm, as well as buster.

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -26,6 +26,11 @@ jobs:
   latest-build:
     name: "Build latest"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        debian-version: [buster,bookworm]
+
     steps:
       - uses: actions/checkout@v4
       - name: Publish to Registry
@@ -36,7 +41,7 @@ jobs:
           password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
           dockerfile: Dockerfile
           buildargs: BASE=buster
-          tags: "latest,buster"
+          tags: "latest,${{ matrix.debian-version }}"
 
   build:
     name: "Build versions"
@@ -48,6 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         perl-version: ${{ fromJson (needs.prepare-matrix.outputs.perl-versions) }}
+        debian-version: [buster,bookworm]
 
     steps:
       - uses: actions/checkout@v4
@@ -58,5 +64,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
           dockerfile: Dockerfile
-          buildargs: BASE=${{ matrix.perl-version }}-buster,CPANOUTDATED=${{ matrix.perl-version != '5.8' }}
-          tags: "${{ matrix.perl-version }}"
+          buildargs: BASE=${{ matrix.perl-version }}-${{ matrix.debian-version }},CPANOUTDATED=${{ matrix.perl-version != '5.8' }}
+          tags: "${{ matrix.perl-version }}-${{ matrix.debian-version }}${{ matrix.debian-version=='buster' && format(',{0}',matrix.perl-version) || '' }}"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ This is tracking the last Perl `devel` version released.
 
 ## OS flavor
 
-At this time all the images built are based on `buster` distro.
+Images are built for both Debian `buster` and Debian `bookworm`.  The
+versions without an explicit Debian version are `buster`.
 
 # Continuous Integrations
 


### PR DESCRIPTION
Build images for bookworm, as well as buster.  Extend the matrix configuration to cover the base image and appropriate tags changes.  Existing unlabeled tags (e.g. `5.36`) remain buster.

Buster is oldoldstable at this point, and is getting long in the tooth.  For example, it has an old version of git that does not support all the flags we'd like to use in the PAUSE tests.