### PR TITLE
Shrink the images.

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -98,5 +98,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
           dockerfile: Dockerfile
-          buildargs: BASE=${{ matrix.perl-version }}-bookworm,CPANOUTDATED=1
-          tags: "${{ matrix.perl-version }}-bookworm"
+          buildargs: BASE=${{ matrix.perl-version }}-slim-bookworm,CPANOUTDATED=1
+          tags: "${{ matrix.perl-version }}-slim-bookworm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,17 @@ RUN perl -V
 
 RUN apt-get update && \
         apt-get dist-upgrade -y && \
-        apt-get -y --no-install-recommends install aspell aspell-en
+        apt-get -y --no-install-recommends install \
+            aspell aspell-en \
+            build-essential \
+            git
 
 RUN cpanm --self-upgrade || \
     ( echo "# Installing cpanminus:"; curl -sL https://cpanmin.us/ | perl - App::cpanminus )
 
-RUN cpanm -nq App::cpm Carton::Snapshot
+RUN cpanm -nq App::cpm Carton::Snapshot && rm -rf /root/.cpanm
 
-RUN cpm install -g --show-build-log-on-failure --cpanfile /tmp/cpanfile
+RUN cpm install -g --show-build-log-on-failure --cpanfile /tmp/cpanfile && rm -rf /root/.perl-cpm
 
 RUN if [ "x${CPANOUTDATED}" = "x1" ] ; then cpan-outdated --exclude-core -p | xargs -n1 cpanm ; else cpan-outdated --exclude-core -p; fi
 


### PR DESCRIPTION
- Delete cached files used for installing perl modules.  (Saves 650MB!)
- Bookworm only: base on the slim-bookworm base image.

bookworm before: 1.6GB
slim-bookworm: 1.03GB
slim-bookworm clean: 572MB

The larger image (with a ton of files) takes a long time to download and initialize.  (40% of the time to run pause tests in GitHub actions.) A smaller image is faster to download and unpack.

There is a tiny chance that someone relying on the new bookworm image is relying on a package that isn't installed by default in the slim images, but the bookworm image has only existed for a week or so, so there are likely to be very few users.