### PR TITLE
Switch perl-actions/install-with-cpm to v1 tag

### DIFF
--- a/.github/workflows/test-cpanfile.yml
+++ b/.github/workflows/test-cpanfile.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install deps using cpm
-        uses: perl-actions/install-with-cpm@stable
+        uses: perl-actions/install-with-cpm@v1
         with:
           cpanfile: 'cpanfile'
           sudo: false


### PR DESCRIPTION
The current tag 'stable' is 3 years old and uses an old nodejs. The v1 tag is 3 weeks old.