### PR TITLE
Bump minimum version of Docker image to perl 5.10

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -20,7 +20,7 @@ jobs:
         id: action
         uses: perl-actions/perl-versions@main
         with:
-          since-perl: '5.8'
+          since-perl: '5.10'
           with-devel: 'true'
 
   # bookworm base images only exist for 5.36 and newer.
@@ -76,7 +76,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
           dockerfile: Dockerfile
-          buildargs: BASE=${{ matrix.perl-version }}-buster,CPANOUTDATED=${{ matrix.perl-version != '5.8' }}
+          buildargs: BASE=${{ matrix.perl-version }}-buster,CPANOUTDATED=1
           tags: "${{ matrix.perl-version }}-buster,${{ matrix.perl-version }}"
 
   build-bookworm:
@@ -98,5 +98,5 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
           dockerfile: Dockerfile
-          buildargs: BASE=${{ matrix.perl-version }}-bookworm,CPANOUTDATED=${{ matrix.perl-version != '5.8' }}
+          buildargs: BASE=${{ matrix.perl-version }}-bookworm,CPANOUTDATED=1
           tags: "${{ matrix.perl-version }}-bookworm"

--- a/.github/workflows/test-cpanfile.yml
+++ b/.github/workflows/test-cpanfile.yml
@@ -17,7 +17,7 @@ jobs:
         id: action
         uses: perl-actions/perl-versions@main
         with:
-          since-perl: '5.8'
+          since-perl: '5.10'
           with-devel: 'true'
 
   test-job:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ devel
 5.14
 5.12
 5.10
-5.8
 ```
 
 ## devel build
@@ -112,7 +111,7 @@ versions without an explicit Debian version are `buster`.
 
 ## Using the images with GitHub Workflow
 
-Here is a sample workflow for Linux running on all Perl version 5.8 to 5.38
+Here is a sample workflow for Linux running on all Perl version 5.10 to 5.38
 You can save the content in `.github/workflow/linux.yml`.
 
 Note: this example is using cpm to install the dependencies from a cpanfile.
@@ -159,7 +158,6 @@ jobs:
           - '5.14'
           - '5.12'
           - '5.10'
-          - '5.8'
 
     container:
       image: perldocker/perl-tester:${{ matrix.perl-version }}


### PR DESCRIPTION
22 years is a good run.  Some fundamental modules like CPAN::Meta::Requirements require v5.10.

