### PR TITLE
Change default debian version from buster to bookworm

### DIFF
--- a/.github/workflows/test-cpanfile.yml
+++ b/.github/workflows/test-cpanfile.yml
@@ -25,7 +25,7 @@ jobs:
     needs:
       - prepare-matrix
     container:
-      image: perl:${{ matrix.perl-version }}-buster
+      image: perl:${{ matrix.perl-version }}-slim-bookworm
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
We would like to provide CI check for jsonnet profile, for debian, pkg jsonnet exists in 'bookworm' while not 'buster', and it seems 'bookworm' is the current stable version of debian. 