### PR TITLE
Make `:devel` tag produce up-to-date image.

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -21,7 +21,7 @@ jobs:
         uses: perl-actions/perl-versions@main
         with:
           since-perl: '5.8'
-          with-devel: 'true'
+          with-devel: 'false'
 
   # bookworm base images only exist for 5.36 and newer.
   prepare-matrix-bookworm:
@@ -35,7 +35,7 @@ jobs:
         uses: perl-actions/perl-versions@main
         with:
           since-perl: '5.36'
-          with-devel: 'true'
+          with-devel: 'false'
 
   latest-build:
     name: "Build latest"
@@ -56,6 +56,22 @@ jobs:
           dockerfile: Dockerfile
           buildargs: BASE=buster
           tags: "latest,${{ matrix.debian-version }}"
+
+  devel-build:
+    name: "Build latest"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish to Registry
+        uses: elgohr/Publish-Docker-Github-Action@v5
+        with:
+          name: ${{ secrets.DOCKER_REPO }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_GITHUB_TOKEN }}
+          dockerfile: Dockerfile
+          buildargs: BASE=devel-slim-bookworm
+          tags: "devel,devel-slim-bookworm"
 
   build-buster:
     name: "Build versions for buster"


### PR DESCRIPTION
Latest buster devel is (at time of writing this commit message):
```
docker run --rm -ti perl:devel-buster perl -v

This is perl 5, version 37, subversion 11 (v5.37.11) built for x86_64-linux-gnu
```

Whereas bookworm versions:
```
docker run --rm -ti perl:devel-slim-bookworm perl -v

This is perl 5, version 41, subversion 13 (v5.41.13) built for x86_64-linux-gnu
```