### PR TITLE
[publish-to-docker] Use perl-versions with target: perl

### DIFF
--- a/.github/workflows/publish-to-docker.yml
+++ b/.github/workflows/publish-to-docker.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           since-perl: '5.8'
           until-perl: '5.40'
+          target:     'perl'
           with-devel: 'false'
 
   # bookworm base images only exist for 5.36 and newer.
@@ -39,6 +40,7 @@ jobs:
         with:
           since-perl: '5.36'
           until-perl: '5.40'
+          target:     'perl'
           with-devel: 'false'
 
   # Similar to the `matrix-bookworm` job, but also add the default tag like `5.42` to the list
@@ -53,6 +55,7 @@ jobs:
         uses: perl-actions/perl-versions@v2.0
         with:
           since-perl: '5.42'
+          target:     'perl'
           with-devel: 'false'
 
   latest-build:


### PR DESCRIPTION
The default target of `perl-versions` is `perl-tester` (referring to this repository).

The `target` parameter was introduced to handle asynchronicity during the publishing process. The expected workflow is:
- `perl-versions` adds a new version (e.g. upcoming v5.44) to the `perl` target
- the default target (`perl-tester`) still provides 5.42 as the latest, ensuring jobs do not fail with "there is no v5.44 image yet"
- once v5.44 image is successfully created, it is added to the `perl-tester` target