### PR TITLE
Select the App::cpm version based on the target Perl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,13 @@ RUN apt-get update && \
 RUN cpanm --self-upgrade || \
     ( echo "# Installing cpanminus:"; curl -sL https://cpanmin.us/ | perl - App::cpanminus )
 
-RUN cpanm -nq App::cpm Carton::Snapshot && rm -rf /root/.cpanm || \
+RUN set -eux; \
+    if perl -e 'exit(($^V ge v5.24.0) ? 0 : 1)'; then \
+        app_cpm='App::cpm'; \
+    else \
+        app_cpm='App::cpm@0.998003'; \
+    fi; \
+    cpanm -nq "${app_cpm}" Carton::Snapshot && rm -rf /root/.cpanm || \
     { cpanm -nq Carton::Snapshot; rm -rf /root/.cpanm; true; }
 
 RUN if command -v cpm >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repo is used to build Perl Docker images with various pre-installed bits:
 - the `aspell` and `aspell-en` packages
 - `cpanminus`
 - `App::cpm`
+  - `latest` on Perl 5.24 and newer, `0.998003` on Perl 5.22 and older
 - `Devel::Cover`
 - various testing modules
 - Dist::Zilla with some common plugins (for Perl >= 5.20)


### PR DESCRIPTION
Fixes #166 

As described in the issue, the latest version of App::cpm cannot be installed on Perl versions older than 5.24. 
Therefore, for Perl versions older than 5.24, we now explicitly install App::cpm 0.998003, which is the last version compatible with those Perl versions.

<https://metacpan.org/dist/App-cpm/changes#L64-69>
