### PR TITLE
Fix: install fatpacked cpm on Perl < 5.24 and fail loudly if cpm is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,12 @@ RUN set -eux; \
         # App::cpm releases after 0.998003 require Perl >= 5.24 and the
         # 0.998003 CPAN release no longer installs on older Perls, so use
         # the self-contained (fatpacked) cpm script, which has no CPAN deps.
-        curl -fsSL https://raw.githubusercontent.com/skaji/cpm/0.998003/cpm -o /usr/local/bin/cpm; \
+        # The commit SHA below is what tag 0.998003 points to, pinned so the
+        # download is immutable; the checksum guards the script we run as root.
+        # Note: only the cpm executable is installed here; App::cpm is not in
+        # site_perl (downstream tooling only invokes the CLI).
+        curl -fsSL --retry 3 https://raw.githubusercontent.com/skaji/cpm/1aa61b3c6c8aea2df7a8802206294d268422ccef/cpm -o /usr/local/bin/cpm; \
+        echo '6a27e528cf37635773e738db36c4b4ab4345d5a9d00b8cbd2f2dc01abc73177d  /usr/local/bin/cpm' | sha256sum -c -; \
         chmod +x /usr/local/bin/cpm; \
         cpanm -nq Carton::Snapshot; \
     fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,18 +37,19 @@ RUN cpanm --self-upgrade || \
 
 RUN set -eux; \
     if perl -e 'exit(($^V ge v5.24.0) ? 0 : 1)'; then \
-        app_cpm='App::cpm'; \
+        cpanm -nq App::cpm Carton::Snapshot; \
     else \
-        app_cpm='App::cpm@0.998003'; \
+        # App::cpm releases after 0.998003 require Perl >= 5.24 and the
+        # 0.998003 CPAN release no longer installs on older Perls, so use
+        # the self-contained (fatpacked) cpm script, which has no CPAN deps.
+        curl -fsSL https://raw.githubusercontent.com/skaji/cpm/0.998003/cpm -o /usr/local/bin/cpm; \
+        chmod +x /usr/local/bin/cpm; \
+        cpanm -nq Carton::Snapshot; \
     fi; \
-    cpanm -nq "${app_cpm}" Carton::Snapshot && rm -rf /root/.cpanm || \
-    { cpanm -nq Carton::Snapshot; rm -rf /root/.cpanm; true; }
+    rm -rf /root/.cpanm; \
+    cpm --version
 
-RUN if command -v cpm >/dev/null 2>&1; then \
-        cpm install -g --show-build-log-on-failure --cpanfile /tmp/cpanfile && rm -rf /root/.perl-cpm; \
-    else \
-        cpanm --notest --installdeps /tmp/ && rm -rf /root/.cpanm; \
-    fi
+RUN cpm install -g --show-build-log-on-failure --cpanfile /tmp/cpanfile && rm -rf /root/.perl-cpm
 
 RUN if [ "x${CPANOUTDATED}" = "x1" ] ; then cpan-outdated --exclude-core -p | xargs -n1 cpanm ; else cpan-outdated --exclude-core -p; fi
 


### PR DESCRIPTION
Closes #185

## Changes
- **Perl < 5.24**: install the self-contained fatpacked `cpm` script instead of `App::cpm@0.998003` from CPAN, whose unpinned dependencies (skaji's supporting modules, all bumped to v1.0.0) no longer configure on old Perls. The download is pinned to the commit SHA that tag `0.998003` points to and verified against a sha256 checksum before being made executable.
- **Perl >= 5.24**: `cpanm -nq App::cpm Carton::Snapshot` with no failure-tolerant fallback.
- **Fail loudly**: the silent `|| { ...; true; }` fallback is gone, and the layer ends with `cpm --version`, so an image can no longer build green without a working `cpm`.
- The cpanfile-install step now uses `cpm` unconditionally — the `command -v cpm` fallback to `cpanm --installdeps` is dead code once cpm is guaranteed, and keeping it would just mask a broken state.
- `Carton::Snapshot` still installs cleanly on 5.8 and 5.22 (verified), so it remains a hard requirement on the old-Perl path too.

## Testing
- Full `docker build --build-arg BASE=5.22-buster` of this branch succeeds; the resulting image has `cpm 0.998003` in PATH, the entire cpanfile installed via the fatpacked cpm, and `cpan-install-dist-deps` present.
- The old-Perl install path was run verbatim on `perl:5.8-buster` and `perl:5.22-buster`: checksum verifies, `cpm --version` works, and `cpm install -g` of a real module succeeds (the fatpacked script declares `use 5.8.1`, matching the matrix floor of 5.8).
- The modern path was run on `perl:5.36-bookworm`: `App::cpm` (currently v1.1.1) installs and runs.
- Without the fix, `cpanm -nq App::cpm@0.998003` fails to configure on 5.22 (per the issue), which previously slipped through the silent fallback — that failure mode now aborts the build.

## Follow-ups (pre-existing, out of scope)
- The cpanminus bootstrap (`curl -sL https://cpanmin.us/ | perl -`) lacks `-f`, so an HTTP error page would be piped into perl.
- `ARG CPANOUTDATED` is commented out after `FROM`, so the `CPANOUTDATED=1` branch in the cpan-outdated step appears unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)